### PR TITLE
PHP 8 bug fix & dependencies upgrade

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,11 +1,12 @@
-FROM php:7.1-cli
+FROM php:7.4.0-cli
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
+    unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pecl install xdebug-beta
+RUN pecl install xdebug
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 ENV XDEBUGINI_PATH=/usr/local/etc/php/conf.d/xdebug.ini

--- a/.docker/xdebug.ini
+++ b/.docker/xdebug.ini
@@ -1,7 +1,4 @@
-xdebug.remote_enable=on
-xdebug.remote_autostart=off
-xdebug.remote_connect_back=off
-xdebug.profiler_enable=0
-xdebug.profiler_output_dir="/var/www/html"
-xdebug.remote_port=9000
-xdebug.remote_host="172.17.0.1"
+xdebug.mode=coverage
+xdebug.output_dir="/var/www/html"
+xdebug.client_port=9000
+xdebug.client_host="172.17.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
+  - 7.4
+  - 8.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "kirouane/interval",
-  "description": "Library to handel intervals",
+  "name": "vast-ru/interval",
+  "description": "Library to handle intervals",
   "type": "library",
   "keywords": [
     "php", "interval", "period", "time", "algebra", "infinity", "planning", "booking", "exclusion"
@@ -25,24 +25,24 @@
   },
   "config": {
     "platform": {
-      "php": "7.1"
+      "php": "7.4"
     }
   },
   "require": {
-    "php" : ">= 7.1"
+    "php" : ">= 7.4"
   },
   "require-dev": {
-    "phpro/grumphp": "^0.15.2",
-    "infection/infection": "^0.11.5",
-    "phpunit/phpunit": "^7.5",
+    "phpro/grumphp": "^1.3.1",
+    "infection/infection": "^0.21.0",
+    "phpunit/phpunit": "^9.5",
     "mockery/mockery": "^1.2",
     "php-coveralls/php-coveralls": "^2.1",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "phpstan/phpstan": "^0.11.8",
+    "phpstan/phpstan": "^0.12.84",
     "jakub-onderka/php-parallel-lint": "^1.0",
-    "maglnet/composer-require-checker": "^2.0",
+    "maglnet/composer-require-checker": "^3.2",
     "phpmd/phpmd": "^2.6",
-    "sebastian/phpcpd": "^4.1",
-    "sensiolabs/security-checker": "^5.0"
+    "sebastian/phpcpd": "^6.0",
+    "sensiolabs/security-checker": "^6.0"
   }
 }

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
     git_hook_variables:
         EXEC_GRUMPHP_COMMAND: docker-compose exec -T php
     ascii:
@@ -33,8 +31,9 @@ parameters:
                 - "die("
                 - "var_dump("
                 - "exit;"
-        phpcsfixer: ~
+        phpcsfixer:
+            config: .php_cs
         phplint: ~
         phpparser: ~
         phpstan: ~
-        securitychecker: ~
+        securitychecker_local: ~

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,20 @@
+<?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-        backupGlobals="true"
-        cacheTokens="false">
-    <testsuites>
-        <testsuite name="interval">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        backupGlobals="true">
+  <testsuites>
+    <testsuite name="interval">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging/>
 </phpunit>

--- a/src/Parser/IntervalParser.php
+++ b/src/Parser/IntervalParser.php
@@ -134,7 +134,7 @@ class IntervalParser
      */
     private function isInt(string $value): bool
     {
-        return \is_numeric($value) && (float)\round($value, 0) === (float)$value;
+        return \is_numeric($value) && (float)\round((float)$value, 0) === (float)$value;
     }
 
     /**

--- a/tests/unit/Boundary/IntegerTest.php
+++ b/tests/unit/Boundary/IntegerTest.php
@@ -219,7 +219,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function equalToTest()
     {
         $bounday = new Integer(1, true);
-        $this->assertInternalType('boolean', $bounday->equalTo(new Integer(1, true)));
+        $this->assertTrue($bounday->equalTo(new Integer(1, true)));
     }
 
     /**
@@ -228,7 +228,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function greaterThanTest()
     {
         $bounday = new Integer(1, true);
-        $this->assertInternalType('boolean', $bounday->greaterThan(new Integer(1, true)));
+        $this->assertFalse($bounday->greaterThan(new Integer(1, true)));
     }
 
     /**
@@ -237,7 +237,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function lessThanTest()
     {
         $bounday = new Integer(1, true);
-        $this->assertInternalType('boolean', $bounday->lessThan(new Integer(1, true)));
+        $this->assertFalse($bounday->lessThan(new Integer(1, true)));
     }
 
     /**
@@ -246,7 +246,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function greaterThanOrEqualToTest()
     {
         $bounday = new Integer(1, true);
-        $this->assertInternalType('boolean', $bounday->greaterThanOrEqualTo(new Integer(1, true)));
+        $this->assertTrue($bounday->greaterThanOrEqualTo(new Integer(1, true)));
     }
 
     /**
@@ -255,7 +255,7 @@ class IntegerTest extends \PHPUnit\Framework\TestCase
     public function lessThanOrEqualToTest()
     {
         $bounday = new Integer(1, true);
-        $this->assertInternalType('boolean', $bounday->lessThanOrEqualTo(new Integer(1, true)));
+        $this->assertTrue($bounday->lessThanOrEqualTo(new Integer(1, true)));
     }
 
     public function toStringProvider()

--- a/tests/unit/IntervalTest.php
+++ b/tests/unit/IntervalTest.php
@@ -23,7 +23,6 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Exception
      * @dataProvider constructorShouldThrowExceptionProvider
      * @param mixed $start
      * @param mixed $end
@@ -31,6 +30,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
      */
     public function constructorShouldThrowException($start, $end)
     {
+        $this->expectException(\Exception::class);
         return new \Interval\Interval($start, $end);
     }
 
@@ -40,7 +40,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function union()
     {
         $interval = new \Interval\Interval(1, 2);
-        $this->assertInstanceOf(Intervals::class, $interval->union(new \Interval\Interval(2, 3)));
+        $this->assertEquals(new Intervals([new Interval(1, 3)]), $interval->union(new \Interval\Interval(2, 3)));
     }
 
     /**
@@ -49,7 +49,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function intersection()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInstanceOf(Interval::class, $interval->intersect(new \Interval\Interval(3, 5)));
+        $this->assertEquals(new Interval(3, 4), $interval->intersect(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -58,7 +58,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function exclusion()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInstanceOf(Intervals::class, $interval->exclude(new \Interval\Interval(3, 5)));
+        $this->assertEquals(new Intervals([new Interval(1, 3, false, true)]), $interval->exclude(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -67,7 +67,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function includes()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->includes(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->includes(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -76,7 +76,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function overlaps()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->overlaps(new \Interval\Interval(3, 5)));
+        $this->assertTrue($interval->overlaps(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -85,7 +85,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function isNeighborBeforeOf()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->isNeighborBefore(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->isNeighborBefore(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -94,7 +94,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function isNeighborAfterOf()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->isNeighborAfter(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->isNeighborAfter(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -103,7 +103,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function isBeforeOf()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->isBefore(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->isBefore(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -112,7 +112,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function isAfter()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->isAfter(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->isAfter(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -121,7 +121,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function starts()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->starts(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->starts(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -130,7 +130,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function ends()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->ends(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->ends(new \Interval\Interval(3, 5)));
     }
 
     /**
@@ -139,7 +139,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     public function equals()
     {
         $interval = new \Interval\Interval(1, 4);
-        $this->assertInternalType('bool', $interval->equals(new \Interval\Interval(3, 5)));
+        $this->assertFalse($interval->equals(new \Interval\Interval(3, 5)));
     }
 
     public function toStringProvider()
@@ -207,11 +207,11 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      * @dataProvider toComparableExceptionProvider
-     * @expectedException UnexpectedValueException
      * @param mixed $boundary
      */
     public function toComparableException($boundary)
     {
+        $this->expectException(\UnexpectedValueException::class);
         Interval::toComparable($boundary);
     }
 

--- a/tests/unit/IntervalsTest.php
+++ b/tests/unit/IntervalsTest.php
@@ -113,7 +113,6 @@ class IntervalsTest extends \PHPUnit\Framework\TestCase
             new Interval(17, 18),
         ]));
 
-        $this->assertInstanceOf(Intervals::class, $results);
         $this->assertCount(4, $results);
     }
 }

--- a/tests/unit/Parser/IntervalParserTest.php
+++ b/tests/unit/Parser/IntervalParserTest.php
@@ -40,7 +40,6 @@ class IntervalParserTest extends \PHPUnit\Framework\TestCase
 
         /** @var Interval $interval */
         $interval = $parser->parse($expression);
-        $this->assertInstanceOf(Interval::class, $interval);
         if ($start instanceof \DateTimeInterface) {
             self::assertInstanceOf(DateTime::class, $interval->getStart());
             self::assertInstanceOf(DateTime::class, $interval->getEnd());
@@ -83,13 +82,13 @@ class IntervalParserTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Exception
      * @dataProvider parseExceptionProvider
      * @param mixed $expression
      */
     public function parseException($expression)
     {
         $parser = new IntervalParser();
+        $this->expectException(\Exception::class);
         $parser->parse($expression);
     }
 
@@ -115,7 +114,6 @@ class IntervalParserTest extends \PHPUnit\Framework\TestCase
 
         /** @var Interval $interval */
         $interval = $parser->parse($expression);
-        $this->assertInstanceOf(Interval::class, $interval);
         if ($start instanceof \DateTimeInterface) {
             self::assertInstanceOf(\DateTimeInterface::class, $interval->getStart()->getValue());
             $this->assertEquals($start, $interval->getStart()->getValue());

--- a/tests/unit/Parser/IntervalsParserTest.php
+++ b/tests/unit/Parser/IntervalsParserTest.php
@@ -35,7 +35,6 @@ class IntervalsParserTest extends \PHPUnit\Framework\TestCase
 
         /** @var Intervals $intervals */
         $intervals = $parser->parse($expressions);
-        $this->assertInstanceOf(Intervals::class, $intervals);
         $this->assertCount(count($expected), $intervals);
         foreach ($intervals as $i => $interval) {
             self::assertSame($expected[$i][0], $interval->getStart()->getValue());

--- a/tests/unit/Rule/Interval/AfterTest.php
+++ b/tests/unit/Rule/Interval/AfterTest.php
@@ -82,7 +82,6 @@ class AfterTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new After();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/BeforeTest.php
+++ b/tests/unit/Rule/Interval/BeforeTest.php
@@ -82,7 +82,6 @@ class BeforeTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new Before();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/EndingTest.php
+++ b/tests/unit/Rule/Interval/EndingTest.php
@@ -82,7 +82,6 @@ class EndingTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new Ending();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/EquilityTest.php
+++ b/tests/unit/Rule/Interval/EquilityTest.php
@@ -82,7 +82,6 @@ class EquilityTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new Equality();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/InclusionTest.php
+++ b/tests/unit/Rule/Interval/InclusionTest.php
@@ -92,7 +92,6 @@ class InclusionTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new Inclusion();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/NeighborhoodAfterTest.php
+++ b/tests/unit/Rule/Interval/NeighborhoodAfterTest.php
@@ -82,7 +82,6 @@ class NeighborhoodAfterTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new NeighborhoodAfter();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/NeighborhoodBeforeTest.php
+++ b/tests/unit/Rule/Interval/NeighborhoodBeforeTest.php
@@ -82,7 +82,6 @@ class NeighborhoodBeforeTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new NeighborhoodBefore();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 

--- a/tests/unit/Rule/Interval/StartingTest.php
+++ b/tests/unit/Rule/Interval/StartingTest.php
@@ -82,7 +82,6 @@ class StartingTest extends \PHPUnit\Framework\TestCase
     {
         $asserter  = new Starting();
         $result    = $asserter->assert(new Interval($firstStart, $firstEnd), new Interval($secondStart, $secondEnd));
-        $this->assertInternalType('bool', $result);
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
- Fixed Error in `\Interval\Parser\IntervalParser::isInt`: `round(): Argument #1 ($num) must be of type int|float, string given`
- Upgraded dependencies and dropped PHP 7.1-7.3 support